### PR TITLE
Add a SHIFT LOCK key mapping and remap F11 to COPY

### DIFF
--- a/Help/keyboard.html
+++ b/Help/keyboard.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>BeebEm - BBC Micro and Master Series Emulator</title>
@@ -98,7 +98,7 @@
 
         <tr>
           <td><kbd>F10</kbd> and <kbd>F11</kbd></td>
-          <td><kbd>F10</kbd> and <kbd>F11</kbd></td>
+          <td><kbd>F10</kbd></td>
           <td><kbd>f0</kbd></td>
         </tr>
 
@@ -152,8 +152,14 @@
 
         <tr>
           <td><kbd>End</kbd></td>
-          <td><kbd>F11</kbd> and <kbd>fn</kbd>+<kbd>→</kbd></kbd></td>
+          <td><kbd>F11</kbd></td>
           <td><kbd>Copy</kbd></td>
+        </tr>
+
+        <tr>
+          <td></td>
+          <td><kbd>F13</kbd></td>
+          <td><kbd>Shift Lock</kbd></td>
         </tr>
       </table>
 

--- a/XCode/Project/Src/MacBridge/BeebEm-Bridging-Keyboard.cpp
+++ b/XCode/Project/Src/MacBridge/BeebEm-Bridging-Keyboard.cpp
@@ -159,9 +159,9 @@ VK_F7, // F7
 VK_F8, // F8
 VK_F9, // F9
 0,
-VK_END, // f11
+VK_END, // [COPY - F11] 103
 0,
-VK_F13, //[BREAK - F13] 105
+VK_F11, // [SHIFT LOCK - F13] 105
 0,
 0,
 0,


### PR DESCRIPTION
The SHIFT LOCK key (little used on the BBC Micro) was not mapped to a key on the Mac keyboard, though in BeebEm Windows it was mapped from F11.

I propose mapping Mac F11 to the much more frequently used Beeb COPY key. The Mac End key was previously mapped to Beeb COPY, but most Macs don't have an End key, making this awkward.

The rarely needed SHIFT LOCK key can be then be mapped from the Mac F13 key, which only full-sized Mac keyboards have. It won't be missed by most users who don't have a full-sized keyboard.

This commit also fixes the fact that BREAK was mapped from both F12 _and_ F13.

Old mapping:

    End        -> COPY 
    (unmapped) -> SHIFT_LOCK 
    F12, F13   -> BREAK 

New mapping:

    F11 -> COPY
    F12 -> BREAK 
    F13 -> SHIFT_LOCK 

Note that the new mapping for COPY is consistent with the information that was already in Help/keyboard.html which already claimed that Mac F11 mapped to COPY.